### PR TITLE
pip install scrapy (lowercase)

### DIFF
--- a/docs/intro/install.rst
+++ b/docs/intro/install.rst
@@ -27,7 +27,7 @@ To install Scrapy using ``conda``, run::
 Alternatively, if you’re already familiar with installation of Python packages,
 you can install Scrapy and its dependencies from PyPI with::
 
-    pip install Scrapy
+    pip install scrapy
 
 Note that sometimes this may require solving compilation issues for some Scrapy
 dependencies depending on your operating system, so be sure to check the


### PR DESCRIPTION
pip is case insensitive, specifying install instructions that appear to be case-sensitive can be confusing for new Python users.

> All comparisons of distribution names MUST be case insensitive, and MUST consider hyphens and underscores to be equivalent.

from https://www.python.org/dev/peps/pep-0426/#name